### PR TITLE
chore: comment out unnecessary dependencies (openssl, python)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,8 +43,8 @@
 
             # add pkgs you want to include
             # see below
-            pkgs.openssl
-            pkgs.python311
+            # pkgs.openssl
+            # pkgs.python311
           ];
 
           npmDeps = importNpmLock.buildNodeModules {


### PR DESCRIPTION
## Content

### Japanese

Node.js 開発環境では必須ではない openssl と python を devShell の依存例からコメントアウトしました。
必要な場合は再度コメントを外して利用できますが、デフォルトでは Node.js 環境に限定するようにしています。

### English
openssl and python are not required in the Node.js development environment, so they have been commented out from the devShell dependency examples.
They can be re-enabled if needed, but by default the environment is now limited to Node.js only.

This makes the environment configuration clearer and avoids including unnecessary dependencies.

## Testing

```
nodejs_nix_env_template (feature/comment_out_non_required) » nix develop
Executing linkNodeModulesHook
Finished executing linkNodeModulesShellHook
bash-5.3$ which python
bash-5.3$ which openssl
/usr/bin/openssl # it's ok because not in  nix store
```
