### PR TITLE
feature: add Taskfile for user experience

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+tasks:
+  install:package:
+    desc: install nodejs package by npm
+    cmds:
+      - npm install -D {{.CLI_ARGS}} --package-lock-only
+
+  install:project:
+    desc: install nodejs project by npm
+    cmds:
+      - npm install --package-lock-only
+
+  uninstall:package:
+    desc: uninstall nodejs package by npm
+    cmds:
+      - npm uninstall -D {{.CLI_ARGS}} --package-lock-only
+
+  build:
+    desc: build source code by tsc
+    cmds:
+      - tsc
+
+  lint:
+    desc: lint source code by eslint
+    cmds:
+      - eslint src/

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           packages = [
             nodejs
             importNpmLock.hooks.linkNodeModulesHook
-            go-task
+            pkgs.go-task
 
             # add pkgs you want to include
             # see below

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
           packages = [
             nodejs
             importNpmLock.hooks.linkNodeModulesHook
+            go-task
 
             # add pkgs you want to include
             # see below


### PR DESCRIPTION
## Content

### Japanese

本プロジェクトでは `npm install package-name --lock-file-only` を押下することが期待されていますが、現実として `--lock-file-only` オプションは忘れやすいという問題があります。そこでTaskfileを利用したAliasを作成しました。`npm run` で起動するものも合せて追加しています。なお、Taskfileを起動するために flake.nix に依存を追加しています。

### English

In this project, it is expected to run npm install package-name --lock-file-only.
However, in practice, the --lock-file-only option is often forgotten.
To address this, I added an alias using Taskfile, along with a corresponding npm run command.

Additionally, a dependency was added to flake.nix in order to enable Taskfile execution.

## Testing

```shell
nodejs_nix_env_template (feature/taskfile) » nix develop            ~/hobby/nodejs_nix_env_template
Executing linkNodeModulesHook
Finished executing linkNodeModulesShellHook
bash-5.3$ task
task: Available tasks for this project:
* build:                   build source code by tsc
* lint:                    lint source code by eslint
* install:package:         install nodejs package by npm
* install:project:         install nodejs project by npm
* uninstall:package:       uninstall nodejs package by npm
task: Task "default" does not exist
bash-5.3$ task build
task: [build] tsc
bash-5.3$ task lint
task: [lint] eslint src/

/Users/shunsock/hobby/nodejs_nix_env_template/src/linter_check.ts
  10:1   error  Unexpected var, use let or const instead          no-var
  10:5   error  'count' is assigned a value but never used        @typescript-eslint/no-unused-vars
  21:28  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
  26:7   error  'unusedValue' is assigned a value but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (4 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

task: Failed to run task "lint": exit status 1
bash-5.3$ task install:package -- hono
task: [install:package] npm install -D hono --package-lock-only

up to date, audited 122 packages in 637ms

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
bash-5.3$ task uninstall:package -- hono
task: [uninstall:package] npm uninstall -D hono --package-lock-only

up to date, audited 121 packages in 386ms

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
bash-5.3$ task install:project
task: [install:project] npm install --package-lock-only

up to date, audited 121 packages in 672ms

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```